### PR TITLE
Ensure test system can be loaded directly

### DIFF
--- a/trivial-file-size.asd
+++ b/trivial-file-size.asd
@@ -22,5 +22,5 @@
   :perform (test-op (o c)
                     (symbol-call :trivial-file-size/tests
                                  '#:run-file-size-tests))
-  :depends-on ("fiveam")
+  :depends-on ("fiveam" "trivial-file-size")
   :components ((:file "tests")))


### PR DESCRIPTION
Since test code references the trivial-file-size package, the system definition must explicitly depend-on the system that defines that package.