### PR TITLE
define trivial-file-size for clasp and fix a test

### DIFF
--- a/tests.lisp
+++ b/tests.lisp
@@ -28,7 +28,7 @@
     (is (= 2 (file-size-in-octets file)))))
 
 (test no-such-file
-  (let ((file (resolve-test-file "no-such-file")))
-    (let ((size (file-size-in-octets file)))
-      #+abcl (= size 0)
-      #-abcl (null size))))
+      (let ((file (resolve-test-file "no-such-file")))
+        (let ((size (file-size-in-octets file)))
+          (is #+abcl (= size 0)
+              #-abcl (null size)))))

--- a/trivial-file-size.lisp
+++ b/trivial-file-size.lisp
@@ -49,8 +49,9 @@ Some platforms (e.g. ABCL) may return 0 when the file does not exist."
 
           #+(and ecl unix)
           (stat/ecl path)
+          #+clasp (nth-value 0 (ext:stat namestring))
 
-          #-(or sbcl cmucl ccl clisp allegro abcl gcl
+          #-(or sbcl cmucl ccl clasp clisp allegro abcl gcl
                 (and lispworks unix)
                 (and ecl unix))
           (file-size-from-stream file))


### PR DESCRIPTION
* `test no-such-file` missed an ìs`so it run silently, but did not report success
* use newly defined stat interface for clasp
* test session:
```lisp
CL-USER> (lisp-implementation-type)
"clasp"
CL-USER> (uiop:symbol-call :trivial-file-size/tests '#:run-file-size-tests)

Running test suite TRIVIAL-FILE-SIZE
 Running test NO-SUCH-FILE .
 Running test EMPTY-FILE .
 Running test TWO-BYTE-FILE .
 Running test ONE-BYTE-FILE .
(#<IT.BESE.FIVEAM::TEST-PASSED> #<IT.BESE.FIVEAM::TEST-PASSED>
 #<IT.BESE.FIVEAM::TEST-PASSED> #<IT.BESE.FIVEAM::TEST-PASSED>)
````
* crosscheck with sbcl:
```lisp
* (lisp-implementation-type)
"SBCL"
* (uiop:symbol-call :trivial-file-size/tests '#:run-file-size-tests)

Running test suite TRIVIAL-FILE-SIZE
 Running test EMPTY-FILE .
 Running test ONE-BYTE-FILE .
 Running test TWO-BYTE-FILE .
 Running test NO-SUCH-FILE .
(#<IT.BESE.FIVEAM::TEST-PASSED {1002425773}>
 #<IT.BESE.FIVEAM::TEST-PASSED {100245BC23}>
 #<IT.BESE.FIVEAM::TEST-PASSED {1002492163}>
 #<IT.BESE.FIVEAM::TEST-PASSED {10024C8513}>)
````