### PR TITLE
Fix SBCL type assertion compiler note

### DIFF
--- a/trivial-file-size.lisp
+++ b/trivial-file-size.lisp
@@ -5,7 +5,8 @@
 ;;; "trivial-file-size" goes here. Hacks and glory await!
 
 (deftype file-size ()
-  '(or null (integer 0 *)))
+  #+sbcl '(values (or null (integer 0 *)) &optional)
+  #-sbcl '(or null (integer 0 *)))
 
 (defun file-size-from-stream (file)
   (with-open-file (in file


### PR DESCRIPTION
; note: Type assertion too complex to check:
; (VALUES &OPTIONAL (OR NULL UNSIGNED-BYTE) &REST T).

- Add SBCL specific type-declaration to type `FILE-SIZE`:
  (values ... &optional)
- Now only declared values should be allowed
- On other implementations, type declaration remains unchanged