### PR TITLE
Fix SBCL comparison compiler note

### DIFF
--- a/trivial-file-size.lisp
+++ b/trivial-file-size.lisp
@@ -5,7 +5,7 @@
 ;;; "trivial-file-size" goes here. Hacks and glory await!
 
 (deftype file-size ()
-  #+sbcl '(values (or null (integer 0 *)) &optional)
+  #+sbcl '(values (or null fixnum) &optional)
   #-sbcl '(or null (integer 0 *)))
 
 (defun file-size-from-stream (file)


### PR DESCRIPTION
Changing `FILE-SIZE` type to `FIXNUM` removes _SBCL_ compiler note for inefficient comparisons.
Still I'm not sure if it is a good idea to do this change or leave it how it is.
What do you think?