### PR TITLE
Add universal Lispworks support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ the following Lisps:
 - Allegro CL
 - ABCL
 - GCL
-- LispWorks (on Unix only)
+- LispWorks
 - ECL (on Unix only)
 
 For other Lisps and platforms, we fall back to opening the file and

--- a/trivial-file-size.lisp
+++ b/trivial-file-size.lisp
@@ -46,6 +46,21 @@ Some platforms (e.g. ABCL) may return 0 when the file does not exist."
           #+(and lispworks unix)
           (sys:file-stat-size (sys:get-file-stat namestring))
 
+          #+lispworks8
+          (block nil
+            (hcl:fast-directory-files
+             file
+             #'(lambda (f handle)
+                 (declare (ignore f))
+                 (return (hcl:fdf-handle-size handle)))))
+          #+(and lispworks (not lispworks8))
+          (block nil
+            (hcl:fast-directory-files
+             file
+             #'(lambda (f handle)
+                 (when (string= f (file-namestring file))
+                   (return (hcl:fdf-handle-size handle))))))
+
           #+abcl (stat/abcl namestring)
 
           #+(and ecl unix)

--- a/trivial-file-size.lisp
+++ b/trivial-file-size.lisp
@@ -46,14 +46,14 @@ Some platforms (e.g. ABCL) may return 0 when the file does not exist."
           #+(and lispworks unix)
           (sys:file-stat-size (sys:get-file-stat namestring))
 
-          #+lispworks8
+          #+(and lispworks (not (or unix lispworks4 lispworks5 lispworks6 lispworks7)))
           (block nil
             (hcl:fast-directory-files
              file
              #'(lambda (f handle)
                  (declare (ignore f))
                  (return (hcl:fdf-handle-size handle)))))
-          #+(and lispworks (not lispworks8))
+          #+(and lispworks (not unix) (or lispworks4 lispworks5 lispworks6 lispworks7))
           (block nil
             (hcl:fast-directory-files
              file

--- a/trivial-file-size.lisp
+++ b/trivial-file-size.lisp
@@ -46,7 +46,7 @@ Some platforms (e.g. ABCL) may return 0 when the file does not exist."
           #+(and lispworks unix)
           (sys:file-stat-size (sys:get-file-stat namestring))
 
-          #+(and lispworks (not (or unix lispworks4 lispworks5 lispworks6 lispworks7)))
+          #+(and lispworks (not unix) (not (or lispworks4 lispworks5 lispworks6 lispworks7)))
           (block nil
             (hcl:fast-directory-files
              file


### PR DESCRIPTION
Using `fast-directory-files` facility.

Seems working well on my machine...

Thank you!